### PR TITLE
feat: add postage stamp support for API store

### DIFF
--- a/cmd/migrations/himalaya.go
+++ b/cmd/migrations/himalaya.go
@@ -24,14 +24,15 @@ const (
 )
 
 var (
-	host        string // flag variable, http api host
-	port        int    // flag variable, http api port
-	ssl         bool   // flag variable, uses https for api if set
-	verbosity   string // flag variable, debug level
-	encrypted   bool   // flag variable, uses encryption
-	pin         bool   // flag variable, pins the repaired content
-	dstFilename string // flag variable, destination file
-	logger      logging.Logger
+	host           string // flag variable, http api host
+	port           int    // flag variable, http api port
+	ssl            bool   // flag variable, uses https for api if set
+	verbosity      string // flag variable, debug level
+	encrypted      bool   // flag variable, uses encryption
+	pin            bool   // flag variable, pins the repaired content
+	dstFilename    string // flag variable, destination file
+	postageBatchID string // flag variable, postage batch ID
+	logger         logging.Logger
 )
 
 type stdOutProgressUpdater struct {
@@ -62,7 +63,7 @@ The input is the hex representation of the swarm hash passed as argument, the re
 		newReference, err := repair.FileRepair(
 			cmd.Context(),
 			addr,
-			repair.WithAPIStore(host, port, ssl),
+			repair.WithAPIStore(host, port, ssl, postageBatchID),
 			repair.WithLogger(logger),
 			repair.WithEncryption(encrypted),
 			repair.WithProgressUpdater(&stdOutProgressUpdater{cmd}),
@@ -95,7 +96,7 @@ The input is the hex representation of the swarm hash passed as argument, the re
 		newReference, err := repair.DirectoryRepair(
 			cmd.Context(),
 			addr,
-			repair.WithAPIStore(host, port, ssl),
+			repair.WithAPIStore(host, port, ssl, postageBatchID),
 			repair.WithLogger(logger),
 			repair.WithEncryption(encrypted),
 			repair.WithProgressUpdater(&stdOutProgressUpdater{cmd}),
@@ -115,6 +116,7 @@ func addRepairCommands(root *cobra.Command) {
 		cmd.Flags().BoolVar(&ssl, "ssl", false, "use ssl")
 		cmd.Flags().BoolVar(&encrypted, "encrypt", false, "use encryption")
 		cmd.Flags().BoolVar(&pin, "pin", false, "pin the repaired content")
+		cmd.Flags().StringVar(&postageBatchID, "postage-batch-id", "", "postage stamps batch ID")
 
 		root.AddCommand(cmd)
 	}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,8 @@ module github.com/ethersphere/bee-repair
 go 1.15
 
 require (
-	github.com/ethersphere/bee v0.5.4-0.20210419211605-a63f64b18fd5
+	github.com/ethersphere/bee v0.5.4-0.20210517105158-54b400ebc666
+	github.com/foxcpp/go-mockdns v0.0.0-20201212160233-ede2f9158d15 // indirect
 	github.com/sirupsen/logrus v1.6.0
 	github.com/spf13/cobra v1.0.0
 )

--- a/go.sum
+++ b/go.sum
@@ -157,6 +157,9 @@ github.com/ethereum/go-ethereum v1.9.23 h1:SIKhg/z4Q7AbvqcxuPYvMxf36che/Rq/Pp0Id
 github.com/ethereum/go-ethereum v1.9.23/go.mod h1:JIfVb6esrqALTExdz9hRYvrP0xBDf6wCncIu1hNwHpM=
 github.com/ethersphere/bee v0.5.4-0.20210419211605-a63f64b18fd5 h1:QzrYBRslmkr7AOMChepi/i55yYgQIxKsyGnDOZ2y5E4=
 github.com/ethersphere/bee v0.5.4-0.20210419211605-a63f64b18fd5/go.mod h1:gzfTZ2r1K0et+qGmKmQIpOt2HGEBhHgZ4fIjV86SG1w=
+github.com/ethersphere/bee v0.5.4-0.20210517105158-54b400ebc666 h1:ZutmEO7+AfyuPO1GABzZxZdzLcKWbEwTrgBjAvFcHXE=
+github.com/ethersphere/bee v0.5.4-0.20210517105158-54b400ebc666/go.mod h1:SW7l8Jh2NQ4Un3uwO+mWHv80QDkYIvOz+ZlSH446Tm0=
+github.com/ethersphere/go-storage-incentives-abi v0.1.0 h1:yxNME3q5dha/pUtIYB07DALhhQjd3+uYhGLFqKMXVyg=
 github.com/ethersphere/go-storage-incentives-abi v0.1.0/go.mod h1:SXvJVtM4sEsaSKD0jc1ClpDLw8ErPoROZDme4Wrc/Nc=
 github.com/ethersphere/go-sw3-abi v0.3.2 h1:BVTuSZ9Ph/JJBglU9pCRSch3gDq4g5QEto6KzMYP/08=
 github.com/ethersphere/go-sw3-abi v0.3.2/go.mod h1:BmpsvJ8idQZdYEtWnvxA8POYQ8Rl/NhyCdF0zLMOOJU=
@@ -281,11 +284,13 @@ github.com/gxed/hashland/keccakpg v0.0.1/go.mod h1:kRzw3HkwxFU1mpmPP8v1WyQzwdGfm
 github.com/gxed/hashland/murmur3 v0.0.1/go.mod h1:KjXop02n4/ckmZSnY2+HKcLud/tcmvhST0bie/0lS48=
 github.com/hashicorp/consul/api v1.1.0/go.mod h1:VmuI/Lkw1nC05EYQWNKwWGbkg+FbDBtguAZLlVdkD9Q=
 github.com/hashicorp/consul/sdk v0.1.1/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=
+github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-msgpack v0.5.3/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
+github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/go-rootcerts v1.0.0/go.mod h1:K6zTfqpRlCUIjkwsN4Z+hiSfzSTQa6eBIzfwKfwNnHU=
 github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerXegt+ozgdvDeDU=

--- a/pkg/file/io.go
+++ b/pkg/file/io.go
@@ -89,7 +89,7 @@ func (a *APIStore) Put(ctx context.Context, mode storage.ModePut, chs ...swarm.C
 		if err != nil {
 			return nil, err
 		}
-		if res.StatusCode != http.StatusOK {
+		if res.StatusCode != http.StatusCreated {
 			return nil, fmt.Errorf("upload failed: %v", res.Status)
 		}
 	}

--- a/pkg/file/io.go
+++ b/pkg/file/io.go
@@ -51,10 +51,11 @@ type PutGetter interface {
 type APIStore struct {
 	Client  *http.Client
 	baseUrl string
+	batchID string
 }
 
 // NewAPIStore creates a new APIStore.
-func NewAPIStore(host string, port int, tls bool) PutGetter {
+func NewAPIStore(host string, port int, tls bool, postageBatchID string) PutGetter {
 	scheme := "http"
 	if tls {
 		scheme += "s"
@@ -67,6 +68,7 @@ func NewAPIStore(host string, port int, tls bool) PutGetter {
 	return &APIStore{
 		Client:  http.DefaultClient,
 		baseUrl: u.String(),
+		batchID: postageBatchID,
 	}
 }
 
@@ -80,6 +82,9 @@ func (a *APIStore) Put(ctx context.Context, mode storage.ModePut, chs ...swarm.C
 			return nil, err
 		}
 		req.Header.Set("Content-Type", "application/octet-stream")
+		if a.batchID != "" {
+			req.Header.Set("Swarm-Postage-Batch-Id", a.batchID)
+		}
 		res, err := a.Client.Do(req)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
After enforcing postage stamps on the API, this tool will stop working as we don't include the postage batch ID along with the API request. 